### PR TITLE
Better camera

### DIFF
--- a/Zizzle/scenes/Levels/Level1.tscn
+++ b/Zizzle/scenes/Levels/Level1.tscn
@@ -49,4 +49,8 @@ max_horiz_vel = 400
 
 [node name="Ground" parent="." instance=ExtResource( 1 )]
 position = Vector2( -64, 640 )
+
+[node name="Camera" type="Camera2D" parent="."]
+current = true
+
 [connection signal="collided_with_floor" from="Player" to="." method="_on_Player_collided_with_floor"]

--- a/Zizzle/scenes/player.tscn
+++ b/Zizzle/scenes/player.tscn
@@ -19,13 +19,3 @@ texture = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 1 )
-
-[node name="FollowCamera" type="Camera2D" parent="."]
-offset = Vector2( 0, -50 )
-current = true
-drag_margin_h_enabled = true
-drag_margin_v_enabled = true
-drag_margin_left = 1.0
-drag_margin_top = 0.6
-drag_margin_right = 1.0
-drag_margin_bottom = 0.5

--- a/Zizzle/src/levels/Level1.gd
+++ b/Zizzle/src/levels/Level1.gd
@@ -1,7 +1,24 @@
 extends Node2D
 
+onready var camera = $Camera
+onready var player = $Player
+
+onready var screen_size = get_viewport_rect().size
+
+var CAMERA_SPEED = 0.1
+# Camera is centered, so this places the player at 1/2 - 1/6 = 1/3 on the screen
+onready var CAMERA_DISTANCE_FROM_PLAYER = screen_size.y / 6
 
 
 func _on_Player_collided_with_floor() -> void:
 	print("Game Over!")
 	get_tree().change_scene("res://scenes/GameOver.tscn")
+
+
+func update_camera():
+	var target_y = player.position.y - CAMERA_DISTANCE_FROM_PLAYER
+	camera.position.y = lerp(camera.position.y, target_y, CAMERA_SPEED)
+
+
+func _process(dt):
+	update_camera()

--- a/Zizzle/src/levels/Level1.gd
+++ b/Zizzle/src/levels/Level1.gd
@@ -7,7 +7,9 @@ onready var screen_size = get_viewport_rect().size
 
 var CAMERA_SPEED = 0.1
 # Camera is centered, so this places the player at 1/2 - 1/6 = 1/3 on the screen
-onready var CAMERA_DISTANCE_FROM_PLAYER = screen_size.y / 6
+onready var CAMERA_DEFAULT_PLAYER_DISTANCE = screen_size.y / 6
+# This places the player at 1/2 - 1/4 = 1/4 on the screen
+onready var CAMERA_DOWN_DISTANCE = screen_size.y / 4
 
 
 func _on_Player_collided_with_floor() -> void:
@@ -16,7 +18,14 @@ func _on_Player_collided_with_floor() -> void:
 
 
 func update_camera():
-	var target_y = player.position.y - CAMERA_DISTANCE_FROM_PLAYER
+	var down = Input.is_action_pressed("down")
+	
+	var target_y
+	if down:
+		target_y = player.position.y + CAMERA_DOWN_DISTANCE
+	else:
+		target_y = player.position.y - CAMERA_DEFAULT_PLAYER_DISTANCE
+	
 	camera.position.y = lerp(camera.position.y, target_y, CAMERA_SPEED)
 
 


### PR DESCRIPTION
Smooth camera that keeps the player on the lower third of the screen, allowing you to see upwards. You can also press "down" to move the camera downwards. Make sure to bind the "down" key in the Project Settings.

The camera had to be moved from the Player scene into the Level1 scene for this to work. Preferably in the future we'll have a Main scene, with Level, Player, and Camera as child nodes.