### PR TITLE
Add roof

### DIFF
--- a/Zizzle/project.godot
+++ b/Zizzle/project.godot
@@ -55,6 +55,16 @@ jump={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":32,"unicode":0,"echo":false,"script":null)
  ]
 }
+down={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
+ ]
+}
+debug_roof_up={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":82,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [layer_names]
 

--- a/Zizzle/scenes/Levels/Level1.tscn
+++ b/Zizzle/scenes/Levels/Level1.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=8 format=2]
 
 [ext_resource path="res://scenes/Ground.tscn" type="PackedScene" id=1]
 [ext_resource path="res://scenes/player.tscn" type="PackedScene" id=2]
 [ext_resource path="res://assets/brick.png" type="Texture" id=3]
 [ext_resource path="res://src/levels/Level1.gd" type="Script" id=4]
+[ext_resource path="res://scenes/Roof.tscn" type="PackedScene" id=5]
 
 [sub_resource type="ConvexPolygonShape2D" id=1]
 points = PoolVector2Array( 0, 0, 256, 0, 256, 256, 0, 256 )
@@ -47,10 +48,12 @@ position = Vector2( 1.63965, 3.31268 )
 horiz_accel = 75
 max_horiz_vel = 400
 
+[node name="Roof" parent="." instance=ExtResource( 5 )]
+position = Vector2( 0, -500 )
+
 [node name="Ground" parent="." instance=ExtResource( 1 )]
 position = Vector2( -64, 640 )
 
 [node name="Camera" type="Camera2D" parent="."]
 current = true
-
 [connection signal="collided_with_floor" from="Player" to="." method="_on_Player_collided_with_floor"]

--- a/Zizzle/scenes/Roof.tscn
+++ b/Zizzle/scenes/Roof.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=2 format=2]
+
+[sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 728, 16 )
+
+[node name="Roof" type="KinematicBody2D"]
+
+[node name="ColorRect" type="ColorRect" parent="."]
+margin_left = -728.0
+margin_top = -1440.0
+margin_right = 728.0
+margin_bottom = 16.0
+color = Color( 0, 0, 0, 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )

--- a/Zizzle/scenes/Roof.tscn
+++ b/Zizzle/scenes/Roof.tscn
@@ -1,9 +1,12 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://src/Roof.gd" type="Script" id=1]
 
 [sub_resource type="RectangleShape2D" id=1]
 extents = Vector2( 728, 16 )
 
 [node name="Roof" type="KinematicBody2D"]
+script = ExtResource( 1 )
 
 [node name="ColorRect" type="ColorRect" parent="."]
 margin_left = -728.0

--- a/Zizzle/src/Roof.gd
+++ b/Zizzle/src/Roof.gd
@@ -1,0 +1,22 @@
+extends KinematicBody2D
+
+
+var MOVE_UP_SPEED = 0.1
+onready var target_y = position.y
+
+
+func _ready():
+	pass
+
+
+func move_up(distance):
+	target_y -= distance
+
+
+func _process(dt):
+	var debug_roof_up = Input.is_action_just_pressed("debug_roof_up")
+	
+	if debug_roof_up:
+		move_up(100)
+		
+	position.y = lerp(position.y, target_y, MOVE_UP_SPEED * dt * 60)

--- a/Zizzle/src/levels/Level1.gd
+++ b/Zizzle/src/levels/Level1.gd
@@ -8,7 +8,8 @@ onready var screen_size = get_viewport_rect().size
 
 
 var CAMERA_SPEED = 0.1
-onready var ROOF_CAMERA_OFFSET = camera_adjust_y(50)
+export var ROOF_DISPLAY_HEIGHT = 50  # How much of the roof to show
+onready var ROOF_CAMERA_OFFSET = camera_adjust_y(ROOF_DISPLAY_HEIGHT)
 onready var CAMERA_DEFAULT_PLAYER_DISTANCE = camera_adjust_y((2.0/3.0) * screen_size.y)
 onready var CAMERA_DOWN_DISTANCE = camera_adjust_y((3.0/4.0) * screen_size.y)
 

--- a/Zizzle/src/levels/Level1.gd
+++ b/Zizzle/src/levels/Level1.gd
@@ -9,21 +9,10 @@ onready var screen_size = get_viewport_rect().size
 
 var CAMERA_SPEED = 0.1
 export var ROOF_DISPLAY_HEIGHT = 50  # How much of the roof to show
-onready var ROOF_CAMERA_OFFSET = camera_adjust_y(ROOF_DISPLAY_HEIGHT)
-onready var CAMERA_DEFAULT_PLAYER_DISTANCE = camera_adjust_y((2.0/3.0) * screen_size.y)
-onready var CAMERA_DOWN_DISTANCE = camera_adjust_y((3.0/4.0) * screen_size.y)
 
-
-# Changes a y-value relative to the top of the camera to a y-value in the world.
-# For example, passing 0 will return the y-value of the top of the camera in the world.
-func camera_adjust_y(y: float) -> float:
-	return camera_adjust(Vector2(0, y)).y
-
-
-# Changes a position relative to the top left of the camera to a position in the world.
-# For example, passing (0, 0) will return the position of the top left of the camera in the world.
-func camera_adjust(pos: Vector2) -> Vector2:
-	return pos - camera.position - screen_size / 2
+onready var ROOF_CAMERA_OFFSET = ROOF_DISPLAY_HEIGHT - screen_size.y / 2
+onready var CAMERA_DEFAULT_PLAYER_DISTANCE = (2.0/3.0) * screen_size.y - screen_size.y / 2
+onready var CAMERA_DOWN_DISTANCE = (3.0/4.0) * screen_size.y - screen_size.y / 2
 
 
 func _on_Player_collided_with_floor() -> void:

--- a/Zizzle/src/levels/Level1.gd
+++ b/Zizzle/src/levels/Level1.gd
@@ -2,11 +2,13 @@ extends Node2D
 
 onready var camera = $Camera
 onready var player = $Player
+onready var roof = $Roof
 
 onready var screen_size = get_viewport_rect().size
 
 
 var CAMERA_SPEED = 0.1
+onready var ROOF_CAMERA_OFFSET = 50 - screen_size.y / 2
 # Camera is centered, so this places the player at 1/2 - 1/6 = 1/3 on the screen
 onready var CAMERA_DEFAULT_PLAYER_DISTANCE = screen_size.y / 6
 # This places the player at 1/2 - 1/4 = 1/4 on the screen
@@ -26,7 +28,9 @@ func new_camera_pos(dt: float, camera_pos: Vector2, player_pos: Vector2) -> Vect
 		target_y = player_pos.y + CAMERA_DOWN_DISTANCE
 	else:
 		target_y = player_pos.y - CAMERA_DEFAULT_PLAYER_DISTANCE
-
+	
+	target_y = max(target_y, roof.position.y - ROOF_CAMERA_OFFSET)
+	
 	return Vector2(0.0, lerp(camera_pos.y, target_y, CAMERA_SPEED * dt * 60))
 
 

--- a/Zizzle/src/levels/Level1.gd
+++ b/Zizzle/src/levels/Level1.gd
@@ -8,11 +8,21 @@ onready var screen_size = get_viewport_rect().size
 
 
 var CAMERA_SPEED = 0.1
-onready var ROOF_CAMERA_OFFSET = 50 - screen_size.y / 2
-# Camera is centered, so this places the player at 1/2 - 1/6 = 1/3 on the screen
-onready var CAMERA_DEFAULT_PLAYER_DISTANCE = screen_size.y / 6
-# This places the player at 1/2 - 1/4 = 1/4 on the screen
-onready var CAMERA_DOWN_DISTANCE = screen_size.y / 4
+onready var ROOF_CAMERA_OFFSET = camera_adjust_y(50)
+onready var CAMERA_DEFAULT_PLAYER_DISTANCE = camera_adjust_y((2.0/3.0) * screen_size.y)
+onready var CAMERA_DOWN_DISTANCE = camera_adjust_y((3.0/4.0) * screen_size.y)
+
+
+# Changes a y-value relative to the top of the camera to a y-value in the world.
+# For example, passing 0 will return the y-value of the top of the camera in the world.
+func camera_adjust_y(y: float) -> float:
+	return camera_adjust(Vector2(0, y)).y
+
+
+# Changes a position relative to the top left of the camera to a position in the world.
+# For example, passing (0, 0) will return the position of the top left of the camera in the world.
+func camera_adjust(pos: Vector2) -> Vector2:
+	return pos - camera.position - screen_size / 2
 
 
 func _on_Player_collided_with_floor() -> void:


### PR DESCRIPTION
You can press input event "debug_roof_up" to make the roof move up. This is the placeholder until we get throwable objects working.

In the future, we may consider making the camera move exactly with the roof when it moves up, which looks more visually appealing. What currently happens is that they move upwards with different speeds, which looks a little off.